### PR TITLE
cast `num_rows` in `plot_filters` to int

### DIFF
--- a/tfomics/impress.py
+++ b/tfomics/impress.py
@@ -40,7 +40,7 @@ def plot_filters(W, fig, num_cols=8, alphabet='ACGT', names=None, fontsize=12):
   """plot 1st layer convolutional filters"""
 
   num_filter, filter_len, A = W.shape
-  num_rows = np.ceil(num_filter/num_cols)
+  num_rows = np.ceil(num_filter/num_cols).astype(int)
 
   fig.subplots_adjust(hspace=0.2, wspace=0.2)
   for n, w in enumerate(W):


### PR DESCRIPTION
This avoids a deprecation warning from matplotlib:

```
tfomics/impress.py:47: MatplotlibDeprecationWarning: Passing non-integers as three-element 
position specification is deprecated since 3.3 and will be removed two minor releases later.
  ax = fig.add_subplot(num_rows,num_cols,n+1)
```

this is using matplotlib version 3.3.4